### PR TITLE
[BB-669] Add account provisioning and deprovisioning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,82 +38,81 @@ jobs:
         uses: guyarb/golang-test-annotations@v0.5.1
         with:
           test-results: test.json
-#
-#  test:
-#    permissions:
-#      id-token: write # permission is required or Machine ID will not authenticate with the cluster.
-#      contents: read
-#      pages: write
-#    runs-on: ubuntu-latest
-#    env:
-#      BATON_LOG_LEVEL: debug
-#      # The following parameters are passed to grant/revoke commands
-#      CONNECTOR_GRANT: ${{ vars.GRANT }} 'role:reviewer:member:user:alejandro.bernal@conductorone.com'
-#      CONNECTOR_ENTITLEMENT: ${{ vars.ENTITLEMENT }} 'role:reviewer:member'
-#      CONNECTOR_PRINCIPAL: ${{ vars.PRINCIPAL }} 'alejandro.bernal@conductorone.com'
-#      CONNECTOR_PRINCIPAL_TYPE: ${{ vars.PRINCIPAL_TYPE }}
-#      BATON_TELEPORT_KEY_PATH: auth.pem
-#      BATON_TELEPORT_PROXY_ADDRESS: ${{ secrets.PROXY }}
-#
-#    steps:
-#      - name: Install Go
-#        uses: actions/setup-go@v4
-#        with:
-#          go-version: 1.23.x
-#      - name: Checkout code
-#        uses: actions/checkout@v3
-#      - name: Fetch Teleport binaries
-#        uses: teleport-actions/setup@v1
-#        with:
-#          version: 16.2.0
-#      - name: Fetch credentials using Machine ID
-#        id: auth
-#        uses: teleport-actions/auth@v2
-#        with:
-#          proxy: ${{ secrets.PROXY }}
-#          token: baton
-#          anonymous-telemetry: 1
-#      - name: Check tsh status
-#        run: tsh status
-#      - name: Check tctl status
-#        run: tctl status
-#      - name: Add identity file
-#        run: cp ${{ steps.auth.outputs.identity-file }} auth.pem
-#      - name: Build baton-teleport
-#        run: go build ./cmd/baton-teleport
-#      - name: Run baton-teleport
-#        run: ./baton-teleport
-#      - name: Install baton
-#        run: ./scripts/get-baton.sh && mv baton /usr/local/bin
-#      - name: Get baton resources
-#        run: baton resources
-#      - name: Grant entitlement
-#        if: env.CONNECTOR_ENTITLEMENT != '' && env.CONNECTOR_PRINCIPAL != '' && env.CONNECTOR_PRINCIPAL_TYPE != ''
-#        run: |
-#          ./baton-teleport
-#          ./baton-teleport --grant-entitlement ${{ env.CONNECTOR_ENTITLEMENT }} --grant-principal ${{ env.CONNECTOR_PRINCIPAL }} --grant-principal-type ${{ env.CONNECTOR_PRINCIPAL_TYPE }}
-#      - name: Check for grant before revoking
-#        if: env.CONNECTOR_ENTITLEMENT != '' && env.CONNECTOR_PRINCIPAL != ''
-#        run: |
-#          ./baton-teleport
-#          baton grants --entitlement ${{ env.CONNECTOR_ENTITLEMENT }} --output-format=json | jq -e ".grants | any(.principal.id.resource ==\"${{ env.CONNECTOR_PRINCIPAL }}\")"
-#      - name: Revoke grants
-#        if: env.CONNECTOR_GRANT != ''
-#        run: |
-#          ./baton-teleport
-#          ./baton-teleport --revoke-grant ${{ env.CONNECTOR_GRANT }}
-#      - name: Check grant was revoked
-#        if: env.CONNECTOR_ENTITLEMENT != '' && env.CONNECTOR_PRINCIPAL != ''
-#        run: |
-#           ./baton-teleport
-#           baton grants --entitlement ${{ env.CONNECTOR_ENTITLEMENT }} --output-format=json | jq --exit-status "if .grants then [ .grants[] | select(.principal.id.resource != \"${{ env.CONNECTOR_PRINCIPAL }}\") ] | length == 0 else . end"
-#      - name: Grant entitlement
-#        if: env.CONNECTOR_ENTITLEMENT != '' && env.CONNECTOR_PRINCIPAL != '' && env.CONNECTOR_PRINCIPAL_TYPE != ''
-#        run: |
-#          ./baton-teleport
-#          ./baton-teleport --grant-entitlement ${{ env.CONNECTOR_ENTITLEMENT }} --grant-principal ${{ env.CONNECTOR_PRINCIPAL }} --grant-principal-type ${{ env.CONNECTOR_PRINCIPAL_TYPE }}
-#      - name: Check grant was re-granted
-#        if: env.CONNECTOR_ENTITLEMENT != '' && env.CONNECTOR_PRINCIPAL != ''
-#        run: |
-#          ./baton-teleport
-#          baton grants --entitlement ${{ env.CONNECTOR_ENTITLEMENT }} --output-format=json | jq -e ".grants | any(.principal.id.resource ==\"${{ env.CONNECTOR_PRINCIPAL }}\")"
+
+  test:
+    permissions:
+      id-token: write
+      contents: read
+      pages: write
+    runs-on: ubuntu-latest
+    env:
+      BATON_LOG_LEVEL: debug
+      CONNECTOR_GRANT: ${{ vars.GRANT }}
+      CONNECTOR_ENTITLEMENT: ${{ vars.ENTITLEMENT }}
+      CONNECTOR_PRINCIPAL: ${{ vars.PRINCIPAL }}
+      CONNECTOR_PRINCIPAL_TYPE: ${{ vars.PRINCIPAL_TYPE }}
+      BATON_TELEPORT_KEY_PATH: /opt/machine-id/identity
+      BATON_TELEPORT_PROXY_ADDRESS: ${{ secrets.PROXY }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.23.x
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Fetch Teleport binaries
+        uses: teleport-actions/setup@v1
+        with:
+          version: 16.2.0
+
+      - name: Fetch credentials using Machine ID
+        id: auth
+        uses: teleport-actions/auth@v2
+        with:
+          proxy: ${{ secrets.PROXY }}
+          token: ${{ secrets.TOKEN }}
+          anonymous-telemetry: 1
+
+      - name: Add identity file
+        run: |
+          mkdir -p /opt/machine-id
+          cp ${{ steps.auth.outputs.identity-file }} /opt/machine-id/identity
+
+      - name: Build baton-teleport
+        run: go build ./cmd/baton-teleport
+
+      - name: Run baton-teleport (initial sync)
+        run: ./baton-teleport
+
+      - name: Install baton
+        run: ./scripts/get-baton.sh && mv baton /usr/local/bin
+
+      - name: Grant entitlement
+        run: ./baton-teleport --grant-entitlement="${{ env.CONNECTOR_ENTITLEMENT }}" --grant-principal="${{ env.CONNECTOR_PRINCIPAL }}" --grant-principal-type="${{ env.CONNECTOR_PRINCIPAL_TYPE }}"
+
+      - name: Re-sync after grant
+        run: ./baton-teleport
+
+      - name: Check grant was granted
+        run: baton grants --entitlement="${{ env.CONNECTOR_ENTITLEMENT }}" --output-format=json | jq -e ".grants | any(.principal.id.resource == \"${{ env.CONNECTOR_PRINCIPAL }}\")"
+
+      - name: Revoke grant
+        run: ./baton-teleport --revoke-grant="${{ env.CONNECTOR_GRANT }}"
+
+      - name: Re-sync after revoke
+        run: ./baton-teleport
+
+      - name: Check grant was revoked
+        run: baton grants --entitlement="${{ env.CONNECTOR_ENTITLEMENT }}" --output-format=json | jq --exit-status "if .grants then all(.grants[]; .principal.id.resource != \"${{ env.CONNECTOR_PRINCIPAL }}\") else true end"
+
+      - name: Re-grant entitlement
+        run: ./baton-teleport --grant-entitlement="${{ env.CONNECTOR_ENTITLEMENT }}" --grant-principal="${{ env.CONNECTOR_PRINCIPAL }}" --grant-principal-type="${{ env.CONNECTOR_PRINCIPAL_TYPE }}"
+
+      - name: Re-sync after re-grant
+        run: ./baton-teleport
+
+      - name: Check grant was re-granted
+        run: baton grants --entitlement="${{ env.CONNECTOR_ENTITLEMENT }}" --output-format=json | jq -e ".grants | any(.principal.id.resource == \"${{ env.CONNECTOR_PRINCIPAL }}\")"

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -31,11 +31,34 @@ func (d *Connector) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.R
 	return "", nil, nil
 }
 
-// Metadata returns metadata about the connector.
-func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
+func (d *Connector) Metadata(_ context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
-		DisplayName: "Baton Teleport Connector",
-		Description: "Connector syncing users, and roles from Teleport.",
+		DisplayName: "Teleport Connector",
+		Description: "Connector to sync and provision users into Teleport.",
+		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
+			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
+				"name": {
+					DisplayName: "Username",
+					Required:    true,
+					Description: "The unique username of the user in Teleport.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "name",
+					Order:       1,
+				},
+				"role": {
+					DisplayName: "Role",
+					Required:    false,
+					Description: "The role to assign to the user. Defaults to 'access' if not provided.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "access",
+					Order:       3,
+				},
+			},
+		},
 	}, nil
 }
 

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,6 +2,8 @@ package connector
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 )
@@ -14,4 +16,22 @@ func PopulateOptions(displayName, permission, resource string) []ent.Entitlement
 		ent.WithGrantableTo(roleResourceType, userResourceType),
 	}
 	return options
+}
+
+func cleanResourceName(name string) string {
+	name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+	re := regexp.MustCompile(`[^a-z0-9\-.\+]+`)
+	return re.ReplaceAllString(name, "")
+}
+
+func splitDashSeparatedName(name string) (string, string) {
+	names := strings.SplitN(name, "-", 2)
+	var firstName, lastName string
+	if len(names) > 0 {
+		firstName = names[0]
+	}
+	if len(names) > 1 {
+		lastName = names[1]
+	}
+	return firstName, lastName
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -2,12 +2,16 @@ package connector
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-teleport/pkg/client"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -34,16 +38,19 @@ func userResource(pId *v2.ResourceId, user types.User) (*v2.Resource, error) {
 		accountType = v2.UserTrait_ACCOUNT_TYPE_SYSTEM
 	}
 
-	firstName, lastName := resource.SplitFullName(user.GetName())
+	name := user.GetName()
+
+	firstName, lastName := splitDashSeparatedName(name)
 	profile := map[string]interface{}{
-		"name":       user.GetName(),
+		"name":       name,
 		"user_id":    user.GetMetadata().Revision,
 		"first_name": firstName,
 		"last_name":  lastName,
 	}
 
+	// Teleport does not store an email natively for users.
 	if accountType == v2.UserTrait_ACCOUNT_TYPE_HUMAN {
-		profile["email"] = user.GetName()
+		profile["email"] = name
 	}
 
 	switch user.GetStatus().IsLocked {
@@ -57,21 +64,126 @@ func userResource(pId *v2.ResourceId, user types.User) (*v2.Resource, error) {
 
 	opts := []resource.UserTraitOption{
 		resource.WithUserProfile(profile),
-		resource.WithUserLogin(user.GetName()),
+		resource.WithUserLogin(name),
 		resource.WithStatus(status),
 		resource.WithAccountType(accountType),
 	}
 
 	if accountType == v2.UserTrait_ACCOUNT_TYPE_HUMAN {
-		opts = append(opts, resource.WithEmail(user.GetName(), true))
+		opts = append(opts, resource.WithEmail(name, true))
 	}
 	return resource.NewUserResource(
-		user.GetName(),
+		name,
 		userResourceType,
-		user.GetName(),
+		name,
 		opts,
 		resource.WithParentResourceID(pId),
 	)
+}
+
+func (u *userBuilder) CreateAccountCapabilityDetails(_ context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	return &v2.CredentialDetailsAccountProvisioning{
+		SupportedCredentialOptions: []v2.CapabilityDetailCredentialOption{
+			v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
+		},
+		PreferredCredentialOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
+	}, nil, nil
+}
+
+func (u *userBuilder) CreateAccount(
+	ctx context.Context,
+	accountInfo *v2.AccountInfo,
+	_ *v2.CredentialOptions,
+) (connectorbuilder.CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	newUser, err := createNewUserInfo(accountInfo)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	_, err = u.client.CreateUser(ctx, newUser)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create user: %w", err)
+	}
+
+	token, err := u.client.CreateResetPasswordToken(ctx, &proto.CreateResetPasswordTokenRequest{
+		Name: newUser.GetName(),
+		TTL:  proto.Duration(24 * time.Hour),
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create reset password token: %w", err)
+	}
+
+	userRes, err := userResource(nil, newUser)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	passwordConfigurationLink := &v2.PlaintextData{
+		Name:  "password_configuration_link",
+		Bytes: []byte(token.GetURL()),
+	}
+
+	caResponse := &v2.CreateAccountResponse_SuccessResult{
+		Resource: userRes,
+	}
+
+	return caResponse, []*v2.PlaintextData{passwordConfigurationLink}, nil, nil
+}
+
+func createNewUserInfo(accountInfo *v2.AccountInfo) (*types.UserV2, error) {
+	p := accountInfo.GetProfile().AsMap()
+
+	username, ok := p["name"].(string)
+	if !ok || username == "" {
+		return nil, fmt.Errorf("missing required field: name")
+	}
+
+	// NOTE: In Teleport, every user must be assigned at least one role upon creation.
+	role, _ := p["role"].(string)
+	if role == "" {
+		role = "access"
+	}
+
+	// Teleport usernames must be formed by joining the user's first and last name with a dash (`-`).
+	// This is a common convention required when provisioning new users.
+	name := cleanResourceName(username)
+
+	return &types.UserV2{
+		Kind:    types.KindUser,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: name,
+		},
+		Spec: types.UserSpecV2{
+			Roles: []string{role},
+			Traits: map[string][]string{
+				"logins": {username},
+			},
+		},
+	}, nil
+}
+
+func (u *userBuilder) Delete(ctx context.Context, resourceID *v2.ResourceId) (annotations.Annotations, error) {
+	username := resourceID.GetResource()
+	if username == "" {
+		return nil, fmt.Errorf("missing resource name")
+	}
+
+	user, err := u.client.GetUser(ctx, username, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	if user.GetUserType() != types.UserTypeLocal {
+		return nil, fmt.Errorf("cannot delete federated (non-local) user: %s", username)
+	}
+
+	err = u.client.DeleteUser(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete user: %w", err)
+	}
+
+	return nil, nil
 }
 
 // List returns all the users from the database as resource objects.


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [x] New feature


NOTE: Due to Teleport's security rules, it is not possible to auto-generate and assign passwords to newly created users. Therefore, when a new user is created from ConductorOne, a password reset link (associated with a token) will be sent to a vault. This allows the user to configure the password for their new account.

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)