### PR TITLE
docs: apply C1 rebrand to connector.mdx

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Teleport connector
-og:title: Set up a Teleport connector - ConductorOne docs
-og:description: Integrate your Teleport instance with ConductorOne to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: ConductorOne provides identity governance and just-in-time provisioning for Teleport. Integrate your Teleport instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests.
+og:title: Set up a Teleport connector - C1 docs
+og:description: Integrate your Teleport instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
+description: C1 provides identity governance and just-in-time provisioning for Teleport. Integrate your Teleport instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
 sidebarTitle: Teleport
 ---
 
@@ -10,15 +10,15 @@ sidebarTitle: Teleport
 
 | Resource     | Sync | Provision |
 | :--- | :--- | :--- |
-| Accounts     | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Roles        | <Icon icon="square-check" iconType="solid" color="#65DE23"/> | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |
-| Nodes        | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |           |
-| Apps         | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |           |
-| Databases    | <Icon icon="square-check" iconType="solid" color="#65DE23"/> |           |
+| Accounts     | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Roles        | <Icon icon="square-check" iconType="solid" color="#c937ae"/> | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |
+| Nodes        | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |           |
+| Apps         | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |           |
+| Databases    | <Icon icon="square-check" iconType="solid" color="#c937ae"/> |           |
 
 The Teleport connector supports [automatic account provisioning](/product/admin/account-provisioning).
 
-Due to Teleport's security rules, it is not possible to auto-generate and assign passwords to newly created accounts. When a new Teleport account is created by ConductorOne, a password reset link (associated with a token) will be sent to a [vault](/product/admin/vaults). This allows the user to configure the password for their new account.
+Due to Teleport's security rules, it is not possible to auto-generate and assign passwords to newly created accounts. When a new Teleport account is created by C1, a password reset link (associated with a token) will be sent to a [vault](/product/admin/vaults). This allows the user to configure the password for their new account.
 
 This connector does not support account deprovisioning. You must deprovision accounts directly in Teleport.
 
@@ -26,9 +26,9 @@ This connector does not support account deprovisioning. You must deprovision acc
 
 This connector only supports a self-hosted setup. **Follow these instructions to use the Teleport connector, hosted and run in your own environment.**
 
-See [the connector's README file](https://github.com/ConductorOne/baton-teleport/blob/main/README.md) for information on alternative setup methods. 
+See [the connector's README file](https://github.com/conductorone/baton-teleport/blob/main/README.md) for information on alternative setup methods. 
 
-This guide walks you through setting up the Baton Teleport connector in Kubernetes to run continuously and sync with ConductorOne. The connector uses certificate-based authentication via `tbot` and connects to ConductorOne using client credentials.
+This guide walks you through setting up the Baton Teleport connector in Kubernetes to run continuously and sync with C1. The connector uses certificate-based authentication via `tbot` and connects to C1 using client credentials.
 
 ### Prerequisites
 
@@ -38,17 +38,17 @@ Before you begin, make sure you have:
 - A Teleport cluster with admin access
 - The `tctl` CLI tool configured for your Teleport cluster
 
-### Step 1: ConductorOne setup
+### Step 1: C1 setup
 
 <Warning>
 To complete this task, you'll need:
 
-- The **Connector Administrator** or **Super Administrator** role in ConductorOne
+- The **Connector Administrator** or **Super Administrator** role in C1
 </Warning>
 
 <Steps>
 <Step>
-In ConductorOne, navigate to **Integrations** > **Connectors** > **Add connector**.
+In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
 </Step>
 <Step>
 Search for **Baton** and click **Add**.
@@ -56,16 +56,16 @@ Search for **Baton** and click **Add**.
 <Step>
 Choose how to set up the new Teleport connector: 
 
-   * Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+   * Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
    * Add the connector to a managed app (select from the list of existing managed apps)
 
    * Create a new managed app
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed. 
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed. 
 
-   If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
 </Step>
 <Step>
 Click **Next**.
@@ -339,10 +339,10 @@ data:
 
         # Note: Adjust this URL based on actual release location
         curl -L -o /tmp/baton-teleport.tar.gz \
-            "https://github.com/ConductorOne/baton-teleport/releases/latest/download/baton-teleport_linux_${ARCH}.tar.gz" || \
+            "https://github.com/conductorone/baton-teleport/releases/latest/download/baton-teleport_linux_${ARCH}.tar.gz" || \
         {
             echo "Please manually install baton-teleport binary"
-            echo "Available at: https://github.com/ConductorOne/baton-teleport/releases"
+            echo "Available at: https://github.com/conductorone/baton-teleport/releases"
             tail -f /dev/null
         }
 
@@ -354,7 +354,7 @@ data:
     fi
 
     echo "=== Starting Baton Teleport Connector ==="
-    echo "Connecting to ConductorOne..."
+    echo "Connecting to C1..."
 
     # Run the connector continuously with C1 credentials
     exec /usr/local/bin/baton-teleport \
@@ -393,9 +393,9 @@ spec:
         - name: TELEPORT_IDENTITY_FILE
           value: "/opt/machine-id/identity"
         - name: BATON_CLIENT_ID
-          value: "YOUR_CLIENT_ID"  # Replace with your ConductorOne client ID
+          value: "YOUR_CLIENT_ID"  # Replace with your C1 client ID
         - name: BATON_CLIENT_SECRET
-          value: "YOUR_CLIENT_SECRET"  # Replace with your ConductorOne client secret
+          value: "YOUR_CLIENT_SECRET"  # Replace with your C1 client secret
         volumeMounts:
         - name: tbot-certs
           mountPath: /opt/machine-id
@@ -437,19 +437,19 @@ The connector will start automatically and run continuously, performing the foll
 Install the `baton-teleport` binary (if not available via releases)
 </Step>
 <Step>
-Connect to ConductorOne using your client credentials
+Connect to C1 using your client credentials
 </Step>
 <Step>
-Poll for tasks from ConductorOne periodically
+Poll for tasks from C1 periodically
 </Step>
 <Step>
-Execute sync tasks when requested by ConductorOne
+Execute sync tasks when requested by C1
 </Step>
 <Step>
 Handle provisioning requests when access needs to be granted/revoked
 </Step>
 <Step>
-Send results back to ConductorOne instead of writing to local files
+Send results back to C1 instead of writing to local files
 </Step>
 </Steps>
 
@@ -459,7 +459,7 @@ If the automatic download fails, you can manually install the binary:
 
 ```bash
 # Option 1: Build from source
-git clone git@github.com:ConductorOne/baton-teleport.git
+git clone git@github.com:C1/baton-teleport.git
 cd baton-teleport
 GOOS=linux GOARCH=amd64 go build -o baton-teleport-linux ./cmd/baton-teleport
 kubectl cp baton-teleport-linux $(kubectl get pod -l app=baton-teleport -o jsonpath='{.items[0].metadata.name}'):/usr/local/bin/baton-teleport
@@ -491,7 +491,7 @@ kubectl rollout restart deployment/baton-teleport
 </Step>
 <Step title="Verify connector connectivity:">
    The logs should show:
-   - Successful connection to ConductorOne
+   - Successful connection to C1
    - Periodic polling for tasks
    - Any sync or provisioning activities
 </Step>


### PR DESCRIPTION
Updates `docs/connector.mdx` with the C1 rebrand:

- Renames **ConductorOne** → **C1** in prose, comments, and placeholder text
- Updates brand color `#65DE23` → `#c937ae`
- Lowercases GitHub org name in the repository resource link

URLs that are case-sensitive or functional (distro site, tenant URLs, email addresses, file paths) are unchanged.