### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -459,7 +459,7 @@ If the automatic download fails, you can manually install the binary:
 
 ```bash
 # Option 1: Build from source
-git clone git@github.com:C1/baton-teleport.git
+git clone git@github.com:ConductorOne/baton-teleport.git
 cd baton-teleport
 GOOS=linux GOARCH=amd64 go build -o baton-teleport-linux ./cmd/baton-teleport
 kubectl cp baton-teleport-linux $(kubectl get pod -l app=baton-teleport -o jsonpath='{.items[0].metadata.name}'):/usr/local/bin/baton-teleport


### PR DESCRIPTION
## Summary

Fixes connector doc regressions caught during a sync to the ConductorOne docs site. Specific fixes in this PR:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)
- Restore correct support email `support@c1.ai` (replaces `support@conductorone.com`)
- Restore full `ConductorOne` GitHub org in git clone URL (replaces `C1/`)
- Restore `BATON_PROVISIONING: true` flag in Kubernetes secrets block (with comment)

These corrections prevent the sync bot from reintroducing regressions on future runs.